### PR TITLE
Fix CSV export newline handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -351,8 +351,8 @@
             edges.get().forEach(edge => {
                 const fromNode = nodes.get(edge.from);
                 const toNode = nodes.get(edge.to);
-                const cleanFromLabel = `"${fromNode.label.replace(/"/g, '""')}"`;
-                const cleanToLabel = `"${toNode.label.replace(/"/g, '""')}"`;
+                const cleanFromLabel = `"${fromNode.label.replace(/"/g, '""').replace(/\n/g, ' ')}"`;
+                const cleanToLabel = `"${toNode.label.replace(/"/g, '""').replace(/\n/g, ' ')}"`;
                 const row = [fromNode.id, cleanFromLabel, fromNode.group, toNode.id, cleanToLabel, toNode.group];
                 csvRows.push(row.join(','));
             });


### PR DESCRIPTION
## Summary
- sanitize newline characters in node labels before exporting to CSV

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687fd2a0e45c8324bae8e7e0ee9cf33f