### PR TITLE
Add Heroku NGINX config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,13 @@ The page relies on several libraries delivered via CDN:
 - **Tailwind CSS** for styling
 
 Because the script uses modern JavaScript features such as `crypto.randomUUID()`, a recent version of Chrome, Firefox, Edge or Safari is recommended. The application includes a simple fallback when this API is missing, but a modern browser is still advised. No additional installation is necessary beyond a web browser with internet access.
+
+## Deploying to Heroku
+
+This site can be served on Heroku using the [NGINX buildpack](https://github.com/heroku/heroku-buildpack-nginx). Add the buildpack and deploy with:
+
+```bash
+heroku buildpacks:set heroku-community/nginx
+```
+
+The repository already includes `config/nginx.conf.erb` with a minimal configuration. No `static.json` file is required for this setup.

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -1,0 +1,22 @@
+worker_processes 1;
+daemon off;
+
+events { worker_connections 1024; }
+
+http {
+  include       mime.types;
+  default_type  application/octet-stream;
+
+  sendfile        on;
+  gzip            on;
+
+  server {
+    listen <%= ENV['PORT'] %>;
+    root   <%= ENV['NGINX_ROOT'] || '.' %>;
+    index  index.html;
+
+    location / {
+      try_files $uri $uri/ =404;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `config/nginx.conf.erb` for Heroku's NGINX buildpack
- document Heroku deployment instructions in `README.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687fd4e75e888324a5a5545845b680a3