### PR TITLE
Prevent dropping products onto descendants

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,6 +212,15 @@
         });
     }
 
+    function isDescendant(ancestorId, descendantId) {
+        let current = products.find(p => p.id === descendantId);
+        while (current && current.parentId) {
+            if (current.parentId === ancestorId) return true;
+            current = products.find(p => p.id === current.parentId);
+        }
+        return false;
+    }
+
     // --- DOM ELEMENTS ---
     const productsListEl = document.getElementById('products-list');
     const featuresListEl = document.getElementById('features-list');
@@ -662,6 +671,10 @@
         const draggedProduct = products.find(p => p.id === draggedProductId);
         const targetProduct = products.find(p => p.id === targetProductId);
         if (!draggedProduct || !targetProduct || draggedProductId === targetProductId) return;
+        if (isDescendant(draggedProductId, targetProductId)) {
+            alert('Cannot move a product into one of its descendants.');
+            return;
+        }
 
         const indicator = document.querySelector('.drop-indicator');
         const dropTarget = e.target.closest('.list-item');


### PR DESCRIPTION
## Summary
- add `isDescendant` helper
- block drop operation when moving a product into one of its descendants

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68813bcc02a08324a6ac475c0bbfd6bf